### PR TITLE
Add scripts to make fixtures for importing data from csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ target/
 
 # Project Files
 data/
+fixtures

--- a/atus_api/api/migrations/0003_auto_20150626_0517.py
+++ b/atus_api/api/migrations/0003_auto_20150626_0517.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0002_activity_respondents'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='respondent',
+            name='id',
+        ),
+        migrations.AlterField(
+            model_name='respondent',
+            name='case_id',
+            field=models.BigIntegerField(serialize=False, primary_key=True),
+        ),
+    ]

--- a/atus_api/api/models.py
+++ b/atus_api/api/models.py
@@ -3,7 +3,7 @@ from django.db import models
 
 class Respondent(models.Model):
     stat_wt = models.FloatField()
-    case_id = models.IntegerField()
+    case_id = models.BigIntegerField(primary_key=True)
 
     def __str__(self):
         return str(self.case_id)

--- a/convert_atus_data.py
+++ b/convert_atus_data.py
@@ -68,22 +68,26 @@ with open("atus_api/fixtures/respondents.json", "w") as outfile:
 print("Converting events...")
 events = []
 event_pk_counter = 0
+respondent_counter = 0
 
 for row in rows[1:]:
-    case_id = row[0]
-    tuflwigt = row[1]
-    durations = row[24:]
-    activities = act_header
+    while event_pk_counter < 10000 or respondent_counter < 100:
+        respondent_counter += 1
+        case_id = row[0]
+        tuflwigt = row[1]
+        durations = row[24:]
+        activities = act_header
 
-    for i, duration in enumerate(durations):
-        events.append({"model": "api.Event",
-                        "pk": event_pk_counter,
-                       "fields": {
-                                  "respondent": case_id,
-                                  "activity": activities[i],
-                                  "duration": float(duration) * float(tuflwigt),
-                                  }})
-        event_pk_counter += 1
-        
-with open("atus_api/fixtures/events.json", "w") as outfile:
+
+        for i, duration in enumerate(durations):
+            events.append({"model": "api.Event",
+                            "pk": event_pk_counter,
+                           "fields": {
+                                      "respondent": case_id,
+                                      "activity": activities[i],
+                                      "duration": float(duration) * float(tuflwigt),
+                                      }})
+            event_pk_counter += 1
+
+with open("atus_api/fixtures/events-subset.json", "w") as outfile:
     outfile.write(json.dumps(events))

--- a/convert_atus_data.py
+++ b/convert_atus_data.py
@@ -24,7 +24,7 @@ Respondent:
 
 
 print("Converting activities...")
-users = []
+activities = []
 with open("data/atussum_2014.dat") as infile:
     reader = csv.reader(infile)
     rows = [row for row in reader]
@@ -35,13 +35,13 @@ with open("data/atussum_2014.dat") as infile:
     act_header = [code[1:] for code in act_header]  # Drop the leading t
 
     for activity_code in act_header:
-        users.append({"model": "api.Activity",
-                      "pk": activity_code,
-                      "fields": {
-                          "tier_1": activity_code[:2],
-                          "tier_2": activity_code[:4],
-                          "tier_3": activity_code
-                      }})
+        activities.append({"model": "api.Activity",
+                           "pk": activity_code,
+                           "fields": {
+                                      "tier_1": activity_code[:2],
+                                      "tier_2": activity_code[:4],
+                                      "tier_3": activity_code
+                                      }})
 
 with open("atus_api/fixtures/activities.json", "w") as outfile:
-    outfile.write(json.dumps(users))
+    outfile.write(json.dumps(activities))

--- a/convert_atus_data.py
+++ b/convert_atus_data.py
@@ -45,3 +45,19 @@ with open("data/atussum_2014.dat") as infile:
 
 with open("atus_api/fixtures/activities.json", "w") as outfile:
     outfile.write(json.dumps(activities))
+
+
+print("Converting respondents...")
+demographic_data = [row[0:2] for row in rows[1:]]
+
+respondents = []
+for row in demographic_data:
+    respondents.append({"model": "api.Respondent",
+                        "pk": row[0][4:],
+                        "fields": {
+                                   "case_id": row[0],
+                                   "stat_wt": row[1],
+                                   }})
+
+with open("atus_api/fixtures/respondents.json", "w") as outfile:
+    outfile.write(json.dumps(respondents))

--- a/convert_atus_data.py
+++ b/convert_atus_data.py
@@ -1,0 +1,47 @@
+import csv
+import json
+import datetime
+
+"""
+Models:
+Activity:
+    tier_1: 01
+    tier_2: 0101
+    tier_3: 010101
+
+Event:
+    id
+    activity FK
+    duration
+    respondent FK
+
+Respondent:
+    stat_wt
+    case_id PK
+"""
+
+
+
+
+print("Converting activities...")
+users = []
+with open("data/atussum_2014.dat") as infile:
+    reader = csv.reader(infile)
+    rows = [row for row in reader]
+
+    header = rows[0]
+    data = [row[24:] for row in rows[1:]]
+    act_header = [row[24:] for row in rows[0:1]][0]  # Drop non-activities
+    act_header = [code[1:] for code in act_header]  # Drop the leading t
+
+    for activity_code in act_header:
+        users.append({"model": "api.Activity",
+                      "pk": activity_code,
+                      "fields": {
+                          "tier_1": activity_code[:2],
+                          "tier_2": activity_code[:4],
+                          "tier_3": activity_code
+                      }})
+
+with open("atus_api/fixtures/activities.json", "w") as outfile:
+    outfile.write(json.dumps(users))

--- a/convert_atus_data.py
+++ b/convert_atus_data.py
@@ -21,7 +21,9 @@ Respondent:
 """
 
 
-
+rows = []
+header = []
+act_header = []
 
 print("Converting activities...")
 activities = []
@@ -53,7 +55,7 @@ demographic_data = [row[0:2] for row in rows[1:]]
 respondents = []
 for row in demographic_data:
     respondents.append({"model": "api.Respondent",
-                        "pk": row[0][4:],
+                        "pk": row[0],
                         "fields": {
                                    "case_id": row[0],
                                    "stat_wt": row[1],
@@ -61,3 +63,27 @@ for row in demographic_data:
 
 with open("atus_api/fixtures/respondents.json", "w") as outfile:
     outfile.write(json.dumps(respondents))
+
+
+print("Converting events...")
+events = []
+event_pk_counter = 0
+
+for row in rows[1:]:
+    case_id = row[0]
+    tuflwigt = row[1]
+    durations = row[24:]
+    activities = act_header
+
+    for i, duration in enumerate(durations):
+        events.append({"model": "api.Event",
+                        "pk": event_pk_counter,
+                       "fields": {
+                                  "respondent": case_id,
+                                  "activity": activities[i],
+                                  "duration": float(duration) * float(tuflwigt),
+                                  }})
+        event_pk_counter += 1
+        
+with open("atus_api/fixtures/events.json", "w") as outfile:
+    outfile.write(json.dumps(events))


### PR DESCRIPTION
The script for Events only pulls in a subset (100 respondents --> 38500 Events) due to heroku constraints and time required to import >4 million rows with django loaddata

The Event duration field needs to be normalized (maybe as a method in the model?)
